### PR TITLE
Some additions to the ba_float16 proposal

### DIFF
--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -585,6 +585,13 @@ let unbox_float dbg =
       | cmm -> Cop(mk_load_immut Double, [cmm], dbg)
     )
 
+(* Conversions for 16-bit floats *)
+
+let float_of_float16 dbg c =
+  Cop(Cextcall("caml_double_of_float16", typ_float, [XInt], false), [c], dbg)
+let float16_of_float dbg c =
+  Cop(Cextcall("caml_float16_of_double", typ_int, [XFloat], false), [c], dbg)
+
 (* Complex *)
 
 let box_complex dbg c_re c_im =
@@ -1344,9 +1351,9 @@ let simplif_primitive p : Clambda_primitives.primitive =
   match (p : Clambda_primitives.primitive) with
   | Pduprecord _ ->
       Pccall (default_prim "caml_obj_dup")
-  | Pbigarrayref(_unsafe, n, (Pbigarray_unknown|Pbigarray_float16), _layout) ->
+  | Pbigarrayref(_unsafe, n, Pbigarray_unknown, _layout) ->
       Pccall (default_prim ("caml_ba_get_" ^ string_of_int n))
-  | Pbigarrayset(_unsafe, n, (Pbigarray_unknown|Pbigarray_float16), _layout) ->
+  | Pbigarrayset(_unsafe, n, Pbigarray_unknown, _layout) ->
       Pccall (default_prim ("caml_ba_set_" ^ string_of_int n))
   | Pbigarrayref(_unsafe, n, _kind, Pbigarray_unknown_layout) ->
       Pccall (default_prim ("caml_ba_get_" ^ string_of_int n))

--- a/asmcomp/cmm_helpers.mli
+++ b/asmcomp/cmm_helpers.mli
@@ -176,6 +176,10 @@ val test_bool : Debuginfo.t -> expression -> expression
 val box_float : Debuginfo.t -> expression -> expression
 val unbox_float : Debuginfo.t -> expression -> expression
 
+(** Conversions for 16-bit floats *)
+val float_of_float16 : Debuginfo.t -> expression -> expression
+val float16_of_float : Debuginfo.t -> expression -> expression
+
 (** Complex number creation and access *)
 val box_complex : Debuginfo.t -> expression -> expression -> expression
 val complex_re : expression -> Debuginfo.t -> expression

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -486,7 +486,8 @@ let rec transl env e =
             bigarray_get unsafe elt_kind layout
               (transl env arg1) (List.map (transl env) argl) dbg in
           begin match elt_kind with
-            Pbigarray_float32 | Pbigarray_float64 -> box_float dbg elt
+          | Pbigarray_float16 -> box_float dbg (float_of_float16 dbg elt)
+          | Pbigarray_float32 | Pbigarray_float64 -> box_float dbg elt
           | Pbigarray_complex32 | Pbigarray_complex64 -> elt
           | Pbigarray_int32 -> box_int dbg Pint32 elt
           | Pbigarray_int64 -> box_int dbg Pint64 elt
@@ -494,7 +495,7 @@ let rec transl env e =
           | Pbigarray_caml_int -> tag_int elt dbg
           | Pbigarray_sint8 | Pbigarray_uint8
           | Pbigarray_sint16 | Pbigarray_uint16 -> tag_int elt dbg
-          | Pbigarray_float16 | Pbigarray_unknown -> assert false
+          | Pbigarray_unknown -> assert false
           end
       | (Pbigarrayset(unsafe, _num_dims, elt_kind, layout), arg1 :: argl) ->
           let (argidx, argnewval) = split_last argl in
@@ -502,7 +503,9 @@ let rec transl env e =
             (transl env arg1)
             (List.map (transl env) argidx)
             (match elt_kind with
-              Pbigarray_float32 | Pbigarray_float64 ->
+            | Pbigarray_float16 ->
+                float16_of_float dbg (transl_unbox_float dbg env argnewval)
+            | Pbigarray_float32 | Pbigarray_float64 ->
                 transl_unbox_float dbg env argnewval
             | Pbigarray_complex32 | Pbigarray_complex64 -> transl env argnewval
             | Pbigarray_int32 -> transl_unbox_int dbg env Pint32 argnewval
@@ -514,7 +517,7 @@ let rec transl env e =
             | Pbigarray_sint8 | Pbigarray_uint8
             | Pbigarray_sint16 | Pbigarray_uint16 ->
                 ignore_high_bit_int (untag_int (transl env argnewval) dbg)
-            | Pbigarray_float16 | Pbigarray_unknown -> assert false)
+            | Pbigarray_unknown -> assert false)
             dbg)
       | (Pbigarraydim(n), [b]) ->
           let dim_ofs = 4 + n in

--- a/testsuite/tests/lib-bigarray/specialized.ml
+++ b/testsuite/tests/lib-bigarray/specialized.ml
@@ -1,0 +1,91 @@
+(* TEST *)
+
+open Bigarray
+
+(* Check that type-specialized accesses produce the same results
+   as generic accesses *)
+
+let generic (a: ('a, 'b, 'c) Array1.t) v0 v1 v2 =
+  a.{0} <- v0; a.{1} <- v1; a.{2} <- v2;
+  (a.{0}, a.{1}, a.{2})
+
+let special_float16 (a: (float, float16_elt, c_layout) Array1.t) v0 v1 v2 =
+  a.{0} <- v0; a.{1} <- v1; a.{2} <- v2;
+  (a.{0}, a.{1}, a.{2})
+
+let special_float32 (a: (float, float32_elt, c_layout) Array1.t) v0 v1 v2 =
+  a.{0} <- v0; a.{1} <- v1; a.{2} <- v2;
+  (a.{0}, a.{1}, a.{2})
+
+let special_float64 (a: (float, float64_elt, c_layout) Array1.t) v0 v1 v2 =
+  a.{0} <- v0; a.{1} <- v1; a.{2} <- v2;
+  (a.{0}, a.{1}, a.{2})
+
+let special_int8s (a: (int, int8_signed_elt, c_layout) Array1.t) v0 v1 v2 =
+  a.{0} <- v0; a.{1} <- v1; a.{2} <- v2;
+  (a.{0}, a.{1}, a.{2})
+
+let special_int8u (a: (int, int8_unsigned_elt, c_layout) Array1.t) v0 v1 v2 =
+  a.{0} <- v0; a.{1} <- v1; a.{2} <- v2;
+  (a.{0}, a.{1}, a.{2})
+
+let special_int16s (a: (int, int16_signed_elt, c_layout) Array1.t) v0 v1 v2 =
+  a.{0} <- v0; a.{1} <- v1; a.{2} <- v2;
+  (a.{0}, a.{1}, a.{2})
+
+let special_int16u (a: (int, int16_unsigned_elt, c_layout) Array1.t) v0 v1 v2 =
+  a.{0} <- v0; a.{1} <- v1; a.{2} <- v2;
+  (a.{0}, a.{1}, a.{2})
+
+let special_int32 (a: (int32, int32_elt, c_layout) Array1.t) v0 v1 v2 =
+  a.{0} <- v0; a.{1} <- v1; a.{2} <- v2;
+  (a.{0}, a.{1}, a.{2})
+
+let special_int64 (a: (int64, int64_elt, c_layout) Array1.t) v0 v1 v2 =
+  a.{0} <- v0; a.{1} <- v1; a.{2} <- v2;
+  (a.{0}, a.{1}, a.{2})
+
+let special_int (a: (int, int_elt, c_layout) Array1.t) v0 v1 v2 =
+  a.{0} <- v0; a.{1} <- v1; a.{2} <- v2;
+  (a.{0}, a.{1}, a.{2})
+
+let special_nativeint (a: (nativeint, nativeint_elt, c_layout) Array1.t)
+                      v0 v1 v2 =
+  a.{0} <- v0; a.{1} <- v1; a.{2} <- v2;
+  (a.{0}, a.{1}, a.{2})
+
+let special_complex32 (a: (Complex.t, complex32_elt, c_layout) Array1.t)
+                      v0 v1 v2 =
+  a.{0} <- v0; a.{1} <- v1; a.{2} <- v2;
+  (a.{0}, a.{1}, a.{2})
+
+let special_complex64 (a: (Complex.t, complex64_elt, c_layout) Array1.t)
+                      v0 v1 v2 =
+  a.{0} <- v0; a.{1} <- v1; a.{2} <- v2;
+  (a.{0}, a.{1}, a.{2})
+
+let special_char (a: (char, int8_unsigned_elt, c_layout) Array1.t) v0 v1 v2 =
+  a.{0} <- v0; a.{1} <- v1; a.{2} <- v2;
+  (a.{0}, a.{1}, a.{2})
+
+let test kind special v0 v1 v2 =
+  let a = Array1.create kind c_layout 3 in
+  let s = special a v0 v1 v2 in
+  let g = generic a v0 v1 v2 in
+  assert (s = g)
+
+let _ =
+  test float16 special_float16 1.0 (-2.0) Float.pi;
+  test float32 special_float32 1.0 (-2.0) Float.pi;
+  test float64 special_float64 1.0 (-2.0) Float.pi;
+  test int8_signed special_int8s 123 (-456) 0xFF00FF;
+  test int8_unsigned special_int8u 123 (-456) 0xFF00FF;
+  test int16_signed special_int16s 123 (-456) 0xFF00FF;
+  test int16_unsigned special_int16u 123 (-456) 0xFF00FF;
+  test int32 special_int32 123l (-456l) (0x22334455l);
+  test int64 special_int64 123L (-456L) (0x2233445566778899L);
+  test int special_int 123 (-456) 0xFF00FF;
+  test nativeint special_nativeint 123n (-456n) (0x22334455n);
+  test complex32 special_complex32 Complex.zero Complex.one Complex.i;
+  test complex64 special_complex64 Complex.zero Complex.one Complex.i;
+  test char special_char 'A' '-' 'Z'


### PR DESCRIPTION
As mentioned in https://github.com/ocaml/ocaml/pull/10775:
- make ocamlopt produce specialized get/set code for bigarrays that are statically known to hold FP16 numbers;
- add support for ARMv8 (ARM 64-bit) FP16 conversions.

Added bonus: a test for specialized bigarray accesses (there was none before?).

